### PR TITLE
Roundstart weapon updates

### DIFF
--- a/code/game/machinery/vendor/weapon_kit_vendors.dm
+++ b/code/game/machinery/vendor/weapon_kit_vendors.dm
@@ -83,6 +83,8 @@
 					"Watchtower Kit" = /obj/item/storage/box/bs_kit/watchtower,
 					"Duty Kit" = /obj/item/storage/box/bs_kit/duty,
 					"Cog Kit" = /obj/item/storage/box/bs_kit/cog,
+					"Warthog Omni Kit" = /obj/item/storage/box/bs_kit/rds_omnicarbine, //Chaosstation addition
+					"Vintorez DMR Kit" = /obj/item/storage/box/bs_kit/vintorez, //Chaosstation addition
 					"Ekaterina SMG Kit" = /obj/item/storage/box/bs_kit/ekaterina,
 					"Bounty Kit" = /obj/item/storage/box/bs_kit/bounty,
 					"Second Secondary" = /obj/item/voucher/blackshield/secondary)
@@ -99,6 +101,7 @@
 					"Mosin Kit" = /obj/item/storage/box/bs_kit/mosin,
 					"Duty Kit" = /obj/item/storage/box/bs_kit/duty,
 					"Cog Kit" = /obj/item/storage/box/bs_kit/cog,
+					"Vintorez DMR Kit" = /obj/item/storage/box/bs_kit/vintorez, //Chaosstation addition
 					"Lascore kit" = /obj/item/storage/box/bs_kit/lascore,
 					"Triage Kit" = /obj/item/storage/box/bs_kit/triage,
 					"Ekaterina SMG Kit" = /obj/item/storage/box/bs_kit/ekaterina,

--- a/code/game/objects/items/weapons/storage/hardcases.dm
+++ b/code/game/objects/items/weapons/storage/hardcases.dm
@@ -603,6 +603,7 @@ obj/item/storage/hcases/attackby(obj/item/W, mob/user)
 		options["Bullpup SMG with HV ammo"] = list(/obj/item/gun/projectile/automatic/c20r/sci/preloaded,/obj/item/gun_upgrade/muzzle/silencer,/obj/item/ammo_magazine/smg_35/hv,/obj/item/ammo_magazine/smg_35/hv)
 		options["Soteria \"Sprocket\" laser carbine"] = list(/obj/item/gun/energy/cog/sprocket/preloaded,/obj/item/cell/medium/moebius/high)
 		options["SST \"Humility\" shotgun"] = list(/obj/item/gun/energy/sst/humility/preloaded,/obj/item/cell/medium/moebius/high)
+		options["\"SST System Cost\" light machine gun"] = list(/obj/item/gun/energy/sst/systemcost/preloaded,/obj/item/cell/medium/moebius/super)
 		var/choice = input(user,"Which gun will you take?") as null|anything in options
 		if(src && choice)
 			var/list/things_to_spawn = options[choice]

--- a/code/game/objects/items/weapons/storage/hardcases.dm
+++ b/code/game/objects/items/weapons/storage/hardcases.dm
@@ -600,7 +600,7 @@ obj/item/storage/hcases/attackby(obj/item/W, mob/user)
 		stamped = TRUE
 		var/list/options = list()
 		// Keeping this in case any other "sensible" option for a primary weapon for Lifeline Techs arrives, just add them as an option here.
-		options["Bullpip SMG with HV ammo"] = list(/obj/item/gun/projectile/automatic/c20r/sci/preloaded,/obj/item/gun_upgrade/muzzle/silencer,/obj/item/ammo_magazine/smg_35/hv,/obj/item/ammo_magazine/smg_35/hv)
+		options["Bullpup SMG with HV ammo"] = list(/obj/item/gun/projectile/automatic/c20r/sci/preloaded,/obj/item/gun_upgrade/muzzle/silencer,/obj/item/ammo_magazine/smg_35/hv,/obj/item/ammo_magazine/smg_35/hv)
 		options["Soteria \"Sprocket\" laser carbine"] = list(/obj/item/gun/energy/cog/sprocket/preloaded,/obj/item/cell/medium/moebius/high)
 		options["SST \"Humility\" shotgun"] = list(/obj/item/gun/energy/sst/humility/preloaded,/obj/item/cell/medium/moebius/high)
 		var/choice = input(user,"Which gun will you take?") as null|anything in options

--- a/code/modules/projectiles/guns/energy/projectile/sst.dm
+++ b/code/modules/projectiles/guns/energy/projectile/sst.dm
@@ -134,3 +134,10 @@
 
 	icon_state = iconstring
 	set_item_state(itemstring)
+
+/obj/item/gun/energy/sst/systemcost/preloaded
+
+/obj/item/gun/energy/sst/systemcost/preloaded/New()
+	cell = new /obj/item/cell/medium/moebius/super(src)
+	. = ..()
+	update_icon()

--- a/code/modules/projectiles/guns/energy/projectile/sst.dm
+++ b/code/modules/projectiles/guns/energy/projectile/sst.dm
@@ -138,6 +138,6 @@
 /obj/item/gun/energy/sst/systemcost/preloaded
 
 /obj/item/gun/energy/sst/systemcost/preloaded/New()
-	cell = new /obj/item/cell/medium/moebius/super(src)
+	cell = new /obj/item/cell/large/moebius/super(src)
 	. = ..()
 	update_icon()


### PR DESCRIPTION

## Changelog
:cl: Arrhythmia_V
add: Blackshield troopers and corpsmen now have access to previously rank restricted weaponry
add: Due to staffing issues and general changing colonist behavior, Soteria has now given their lifeline techs access to LMGs.
fix: Fixes spelling error with lifeline tech loadout
/:cl:


